### PR TITLE
Feature Proposal: Introduce GOLANGCI_LINT_WORKSPACE to run the linters in a subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,17 @@ Command and/or arguments to pass to `golangci-lint`. Defaults to `run`.
 
 ### Run `golangci-lint` in a subdirectory
 
+`GOLANGCI_LINT_WORKSPACE` environment variable lets `golangci-lint` run in a specified subdirectory.
+
 ```yaml
-    env:
-      GOLANGCI_LINT_WORKSPACE: ./path/to/dir
-    steps:
-        uses: actions/checkout@v2
-      - name: Run golangci-lint
-        uses: actions-contrib/golangci-lint@master
-        with:
-          args: "run -v"
+env:
+  GOLANGCI_LINT_WORKSPACE: ./path/to/dir
+steps:
+    uses: actions/checkout@v2
+  - name: Run golangci-lint
+    uses: actions-contrib/golangci-lint@master
+    with:
+      args: "run -v"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ Command and/or arguments to pass to `golangci-lint`. Defaults to `run`.
   uses: actions-contrib/golangci-lint@v1
 ```
 
+
+### Run golangci-lint in a sub directory
+
+```yaml
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    env:
+      GOLANGCI_LINT_WORKSPACE: ./path/to/dir
+    steps:
+        uses: actions/checkout@v2
+      - name: Run golangci-lint
+        uses: actions-contrib/golangci-lint@master
+        with:
+          args: "run -v"
+```
+
 ## License
 
 [mit]: https://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -25,12 +25,9 @@ Command and/or arguments to pass to `golangci-lint`. Defaults to `run`.
 ```
 
 
-### Run golangci-lint in a sub directory
+### Run `golangci-lint` in a subdirectory
 
 ```yaml
-jobs:
-  golangci-lint:
-    runs-on: ubuntu-latest
     env:
       GOLANGCI_LINT_WORKSPACE: ./path/to/dir
     steps:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eu
 
-cd "$GITHUB_WORKSPACE"
+if [ -z "$GOLANGCI_LINT_WORKSPACE" ];
+then
+    cd "$GITHUB_WORKSPACE"
+else
+    cd "$GOLANGCI_LINT_WORKSPACE"
+fi
 
 golangci-lint "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/bin/bash
+set -e
 
 if [ -z "$GOLANGCI_LINT_WORKSPACE" ];
 then


### PR DESCRIPTION
Closes #9

When a monorepo manages all go code including `go.mod` in a subdirectory, `actions-contrib/golangci-lint` fails to import Go packages on GIthub Actions.

I don't have such a problem on my local so that something goes wrong only on Github Actions... At least, I can say the current directory of `golangci-lint` matters on Github Actions.

This PR introduces the `GOLANGCI_LINT_WORKSPACE` environment variable which can change the working directory of `golangci-lint` as a workaround. A usual Go project does not need this option so that the default behavior won't be changed.